### PR TITLE
{Acc, NeAcc.Def}: derive {Eq, Ord, Typeable, Data}

### DIFF
--- a/library/Acc.hs
+++ b/library/Acc.hs
@@ -43,7 +43,7 @@ ensuring that you don\'t get stack overflow.
 data Acc a =
   EmptyAcc |
   TreeAcc !(NeAcc.NeAcc a)
-  deriving (Generic, Generic1)
+  deriving (Generic, Generic1, Eq, Ord, Typeable, Data)
 
 instance NFData a => NFData (Acc a)
 

--- a/library/Acc/NeAcc/Def.hs
+++ b/library/Acc/NeAcc/Def.hs
@@ -24,7 +24,7 @@ Relates to 'Acc.Acc' the same way as 'NonEmpty' to list.
 data NeAcc a =
   Leaf !a |
   Branch !(NeAcc a) !(NeAcc a)
-  deriving (Generic, Generic1)
+  deriving (Generic, Generic1, Eq, Ord, Typeable, Data)
 
 instance Show a => Show (NeAcc a) where
   show =


### PR DESCRIPTION
I guess they are simple enough to be derived optimally.

Relates to #1, but not closes it fully.