### PR TITLE
Future-proof against addition of Data.List.unsnoc

### DIFF
--- a/library/Acc/Prelude.hs
+++ b/library/Acc/Prelude.hs
@@ -32,7 +32,7 @@ import Data.Functor.Compose as Exports
 import Data.IORef as Exports
 import Data.Int as Exports
 import Data.Ix as Exports
-import Data.List as Exports hiding (all, and, any, concat, concatMap, elem, find, foldl, foldl', foldl1, foldr, foldr1, isSubsequenceOf, mapAccumL, mapAccumR, maximum, maximumBy, minimum, minimumBy, notElem, or, product, sortOn, sum, uncons)
+import Data.List as Exports hiding (all, and, any, concat, concatMap, elem, find, foldl, foldl', foldl1, foldr, foldr1, isSubsequenceOf, mapAccumL, mapAccumR, maximum, maximumBy, minimum, minimumBy, notElem, or, product, sortOn, sum, uncons, unsnoc)
 import Data.List.NonEmpty as Exports (NonEmpty (..))
 import Data.Maybe as Exports
 import Data.Monoid as Exports hiding (Alt, First (..), Last (..), (<>))


### PR DESCRIPTION
There is a CLC proposal to add `Data.List.unsnoc` to `base`: https://github.com/haskell/core-libraries-committee/issues/165. This draft PR makes `acc` compatible with this potential change.